### PR TITLE
Check that at least one MIDI output exists

### DIFF
--- a/src/components/VideoFrame.jsx
+++ b/src/components/VideoFrame.jsx
@@ -145,12 +145,6 @@ class VideoFrame extends React.Component {
 
     async landmarksRealTime (video) {
 
-      if (WebMidi.outputs.length === 0) {
-        // https://medium.com/@keybaudio/virtual-midi-devices-on-macos-a45cdbdffdaf
-        alert("No MIDI outputs are detected. Either connect a midi device, or create a virtual one. On Mac computers, open 'Audio Midi Setup' > 'MIDI Studio' > double-click IAC Driver > Enable 'Device is online' and refresh this page.");
-      }
-
-
       const midi_output = WebMidi.outputs[0];
       console.log("midi_output in landmarks:  ", midi_output?.name);
       const {model} = this.state;


### PR DESCRIPTION
If a MIDI output is present, proceed as done previously.
If no MIDI output exists, alert the user and prompt a user to connect a MIDI output or create a virtual MIDI.

Perhaps the user should be prompted to connect a device, then click OK, at which point conductor should refresh - alternatively, let the user close the alert and navigate to the main view, but grey out all controls since no MIDI output is available.
Fixes #6 